### PR TITLE
fix/tie breaker face down

### DIFF
--- a/doc/RF - Code Challenge - War Card Game.md
+++ b/doc/RF - Code Challenge - War Card Game.md
@@ -1,13 +1,13 @@
-h1. Build a War Card Game
+# Build a War Card Game
 
-h2. Instructions
+## Instructions
 
 Your task is to build a version of the War card game in Ruby that can be run on the
 command line. There should not be any UI component to the game, and the entire
 project should take two hours or less. Please build the game in accordance with the
 rules below.
 
-h3. Rules
+### Rules
 
 1. A standard 52-card playing card deck is divided evenly amongst two or four
    players. (Each player’s deck is 26 cards for a two-player game, 13 cards for
@@ -17,25 +17,21 @@ h3. Rules
    all 52 cards, at which point the game ends and the player with all the cards
    is the winner.
 
-3.  If there are more than two players, then a player can be eliminated if they
+3. If there are more than two players, then a player can be eliminated if they
     run out of cards. The game continues as usual with the remaining players
     until there is a winner.
 
 4. A round consists of the following:
-
-  A. Each player puts into play the top card of their deck face up.
-
-  B. The player with the face up card of the highest rank wins all the cards in
+  a. Each player puts into play the top card of their deck face up.
+  b. The player with the face up card of the highest rank wins all the cards in
   play, and places them at the bottom of their deck in any order. This
   concludes the round.
-
-  C. If two or more players have equal highest-rank face up cards, those
+  c. If two or more players have equal highest-rank face up cards, those
   players put into play three cards from the top of their decks face down, then
   repeat steps A and B above. If two or more players have equal highest-rank
   face up cards again, repeat step C as many times as needed for the round to
   conclude.
-
-  D. If any player would run out of cards in the middle of a round, then that
+  d. If any player would run out of cards in the middle of a round, then that
   player plays their last card face up, and that card serves as the player’s
   face up card for the remainder of the round.
 
@@ -44,7 +40,7 @@ h3. Rules
 
 6. Suits (hearts, diamonds, spades, clubs) are not relevant to the game.
 
-h2. Submission
+## Submission
 
 Please push your completed code to Github and provide the repository URL within
 24 hours of receiving this challenge. Please provide instructions for how to

--- a/spec/war_of_cards/round_spec.rb
+++ b/spec/war_of_cards/round_spec.rb
@@ -33,22 +33,20 @@ RSpec.describe WarOfCards::Round do
   end
 
   describe "game play" do
-    subject(:winners) { round.winners.first }
-
-    before do
-      winning_player.hand = [WarOfCards::Game::Card.new("A", "hearts")].to_set
-      loosing_player.hand = [WarOfCards::Game::Card.new("2", "spades")].to_set
-
-      allow(winning_player).to receive(:merge_winning).with(
-        cards: a_kind_of(Set)
-      ).and_call_original
-    end
-
-    it "determines a winner in a simple round" do
-      expect(winners[:player]).to eq(winning_player)
-    end
-
     context "when there is a single winner" do
+      before do
+        winning_player.hand = [WarOfCards::Game::Card.new("A", "hearts")].to_set
+        loosing_player.hand = [WarOfCards::Game::Card.new("2", "spades")].to_set
+
+        allow(winning_player).to receive(:merge_winning).with(
+          cards: a_kind_of(Set)
+        ).and_call_original
+      end
+
+      it "determines a winner in a simple round" do
+        expect(round.winners.first[:player]).to eq(winning_player)
+      end
+
       it "gives cards in play to winning player" do
         round.winner_takes_cards_in_play(winner: winning_player)
         expect(winning_player).to have_received(:merge_winning).with(cards: a_kind_of(Set))
@@ -60,7 +58,7 @@ RSpec.describe WarOfCards::Round do
       end
     end
 
-    context "when there no winners" do
+    context "when there are no winners" do
       before do
         winning_player.hand = winning_cards
         loosing_player.hand = loosing_cards
@@ -75,11 +73,12 @@ RSpec.describe WarOfCards::Round do
           WarOfCards::Game::Card.new("9", "hearts")
         ].to_set
       end
+
       let(:loosing_cards) do
         [
           WarOfCards::Game::Card.new("A", "spades"),
           WarOfCards::Game::Card.new("K", "spades"),
-          WarOfCards::Game::Card.new("J", "spades"),
+          WarOfCards::Game::Card.new("K", "clubs"),
           WarOfCards::Game::Card.new("9", "spades"),
           WarOfCards::Game::Card.new("8", "spades")
         ].to_set
@@ -89,48 +88,101 @@ RSpec.describe WarOfCards::Round do
         expect(round.winners.size).to eq(game.players.count)
       end
 
-      it "resolves ties adding 3x cards per player" do
+      it "resolves ties adding 4x cards per player" do
         expect { round.break_ties }.to change {
           round.cards_in_play.size
-        }.by(3 * game.players.size)
+        }.by(4 * game.players.size)
       end
 
-      it "detects tie-breakers", :aggregate_failures do
+      it "breaks simple ties", :aggregate_failures do
+        expect(round.winners.size).to eq(2)
         round.break_ties
-
-        tie_breaker = round.tie_breaker
-        expect(tie_breaker[:player]).to eq(winning_player)
-        expect(tie_breaker[:card_value]).to eq(12)
-        expect(tie_breaker[:card].suit).to eq("Hearts")
+        expect(round.winners.size).to eq(1)
       end
 
-      context "when there no tie-breakers" do
-        before do
-          winning_player.hand = player1_cards
-          loosing_player.hand = player2_cards
-        end
+      it "breaking ties chooses the correct winner" do
+        round.break_ties
+        winner = round.winners.first
 
-        let(:player1_cards) do
-          [
-            WarOfCards::Game::Card.new("A", "hearts"),
-            WarOfCards::Game::Card.new("K", "hearts"),
-            WarOfCards::Game::Card.new("Q", "hearts")
-          ].to_set
-        end
-        let(:player2_cards) do
-          [
-            WarOfCards::Game::Card.new("A", "spades"),
-            WarOfCards::Game::Card.new("K", "spades"),
-            WarOfCards::Game::Card.new("Q", "spades")
-          ].to_set
-        end
-
-        it "detects no tie-breakers", :aggregate_failures do
-          round.break_ties
-
-          expect(round.tie_breaker).to be_nil
-        end
+        expect(winner[:player]).to eq(winning_player)
       end
     end
+
+    # rubocop:disable RSpec/TooManyExampleLines
+    context "when multiple rounds of tie-breaking are needed" do
+      let(:alice) {
+        instance_double(
+          WarOfCards::Player, hand: Set.new,
+          draw_cards: Set.new([WarOfCards::Game::Card.new("A", "hearts")])
+        )
+      }
+      let(:bob) {
+        instance_double(
+          WarOfCards::Player, hand: Set.new,
+          draw_cards: Set.new([WarOfCards::Game::Card.new("A", "spades")])
+        )
+      }
+
+      before do
+        # Mock the merge_winning method to prevent actual card transfer
+        allow(alice).to receive(:merge_winning)
+        allow(bob).to receive(:merge_winning)
+
+        allow(game).to receive_messages(
+          players: [alice, bob].to_set, current_round: round
+        )
+      end
+
+      it "breaks repeated ties" do
+        # Mock the draw_cards method to return cards with same rank values
+        # to force multiple tie-breaking rounds
+        alice_first_draw = [
+          WarOfCards::Game::Card.new(7, "hearts"),
+          WarOfCards::Game::Card.new(8, "hearts"),
+          WarOfCards::Game::Card.new(9, "hearts"),
+          WarOfCards::Game::Card.new("K", "hearts")
+        ].to_set
+
+        bob_first_draw = [
+          WarOfCards::Game::Card.new(1, "spades"),
+          WarOfCards::Game::Card.new(2, "spades"),
+          WarOfCards::Game::Card.new(3, "spades"),
+          WarOfCards::Game::Card.new("K", "spades")
+        ].to_set
+
+        # First draw will have ties, second draw will also have ties
+        allow(alice).to receive(:draw_cards).with(batch_count: 3).and_return(alice_first_draw)
+        allow(bob).to receive(:draw_cards).with(batch_count: 3).and_return(bob_first_draw)
+
+        # First round of tie-breaking
+        round.break_ties
+
+        # Mock the card_value method to return same values for both players
+        # in both draws to ensure tie continues through multiple rounds
+        alice_second_draw = [
+          WarOfCards::Game::Card.new(4, "hearts"),
+          WarOfCards::Game::Card.new(2, "hearts"),
+          WarOfCards::Game::Card.new(6, "hearts"),
+          WarOfCards::Game::Card.new(9, "hearts")
+        ].to_set
+
+        bob_second_draw = [
+          WarOfCards::Game::Card.new(6, "spades"),
+          WarOfCards::Game::Card.new(9, "spades"),
+          WarOfCards::Game::Card.new(7, "spades")
+        ].to_set
+
+        # Simulate another round
+        allow(alice).to receive(:draw_cards).and_return(alice_second_draw)
+        allow(bob).to receive(:draw_cards).and_return(bob_second_draw)
+
+        # Second round of tie-breaking
+        round.break_ties
+
+        # Verify that multiple rounds of tie-breaking were processed
+        expect(round.winners.size).to eq(1)
+      end
+    end
+    # rubocop:enable RSpec/TooManyExampleLines
   end
 end


### PR DESCRIPTION
## Purpose
Addresses issue #1 =~ update war rules to implement "face-down battle" logic.

## Developer notes
@belt self-proclaims he is being "lazy" by telling `hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-1M-GGUF:Q6_K_XL` to update the spec based on the vibe coding for the face-down battle logic,, for the sake of completeness,, despite being past the 24-hour submission deadline.

The 2019 Core i7 MBP only supports AVX1.0 instructions in silicon. AVX2 and ideally AVX512 instruction sets would be available to allow AI coding to happen in human time scales.